### PR TITLE
Added support for meta set without returning

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -900,7 +900,7 @@ func (c *Client) processMetaSet(rw *bufio.ReadWriter, item *MetaSetItem, cb func
 func parseMetaResponseMetadata(metaResponseMetadata []string, respMetadata *MetaResponseMetadata) error {
 	if len(metaResponseMetadata) != 0 {
 		for _, metadata := range metaResponseMetadata {
-			if err := populateMetaResponseMetadata(metadata[0:1], metadata[1:], respMetadata); err != nil {
+			if err := populateMetaResponseMetadata(metadata, respMetadata); err != nil {
 				return err
 			}
 		}
@@ -912,11 +912,10 @@ func parseMetaResponseMetadata(metaResponseMetadata []string, respMetadata *Meta
 }
 
 //populates the MetaResponseMetadata based on the response flags
-func populateMetaResponseMetadata(respFlagKey string,
-	respValue string,
-	respMetadata *MetaResponseMetadata) error {
-
+func populateMetaResponseMetadata(metadata string, respMetadata *MetaResponseMetadata) error {
 	var err error
+	respFlagKey := metadata[0:1]
+	respValue := metadata[1:]
 
 	switch {
 	case respFlagKey == casTokenResponseMetaFlag:

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -755,7 +755,7 @@ type MetaSetItem struct {
 }
 
 type MetaResponseMetadata struct {
-	Value                 []byte
+	ReturnItemValue       []byte
 	CasId                 *uint64
 	ItemKey               *string
 	OpaqueToken           *string

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -275,7 +275,7 @@ func testMetaSetCommandsWithClient(t *testing.T, c *Client, checkErr func(err er
 		t.Errorf("meta set(%s) Key = %q, want %s", key, *response.ItemKey, key)
 	}
 	if *response.OpaqueToken != opaqueToken {
-		t.Errorf("meta set(%s) Opaque token = %s, want %s", key, *response.ItemKey, opaqueToken)
+		t.Errorf("meta set(%s) Opaque token = %s, want %s", key, *response.OpaqueToken, opaqueToken)
 	}
 	casToken := response.CasId
 	if casToken == nil {

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -19,6 +19,7 @@ package memcache
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -88,7 +89,7 @@ func testWithClient(t *testing.T, c *Client) {
 	mustSet := mustSetF(t, c)
 
 	// test meta commands
-	testMetaCommandsWithClient(t, c, checkErr)
+	testMetaSetCommandsWithClient(t, c, checkErr)
 
 	// Set
 	foo := &Item{Key: "foo", Value: []byte("fooval"), Flags: 123}
@@ -264,73 +265,143 @@ func testTouchWithClient(t *testing.T, c *Client) {
 	}
 }
 
-func testMetaCommandsWithClient(t *testing.T, c *Client, checkErr func(err error, format string, args ...interface{})) {
-	// Meta Set
+func testMetaSetCommandsWithClient(t *testing.T, c *Client, checkErr func(err error, format string, args ...interface{})) {
 	key := "bah"
+	value := []byte("bahval")
 	opaqueToken := "A123"
-	metaFoo := &MetaSetItem{Key: key, Value: []byte("bahval"), Flags: MetaSetFlags{ReturnKeyInResponse: true, ReturnCasTokenInResponse: true, OpaqueToken: &opaqueToken}}
+	metaFoo := &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{ReturnKeyInResponse: true, ReturnCasTokenInResponse: true, OpaqueToken: &opaqueToken}}
 	response, err := c.MetaSet(metaFoo)
-	if *response.Key != key {
-		t.Errorf("meta set(%s) Key = %q, want %s", key, *response.Key, key)
+	if *response.ItemKey != key {
+		t.Errorf("meta set(%s) Key = %q, want %s", key, *response.ItemKey, key)
 	}
-	if *response.OpaqueValue != opaqueToken {
-		t.Errorf("meta set(%s) Opaque token = %s, want %s", key, *response.Key, opaqueToken)
+	if *response.OpaqueToken != opaqueToken {
+		t.Errorf("meta set(%s) Opaque token = %s, want %s", key, *response.ItemKey, opaqueToken)
 	}
 	casToken := response.CasId
 	if casToken == nil {
 		t.Errorf("meta set(%s) error, no CAS token returned", key)
 	}
-	checkErr(err, "first meta set(%s): %v", key, err)
+	checkErr(err, "normal meta set(%s): %v", key, err)
+	testMetaSetSavedValue(t, c, checkErr, key, value)
 
 	// set using the same cas token as what was last set
+	value = []byte("new_bah_val")
 	var newTTL int32 = 900000
 	var clientFlagToken uint32 = 90
-	metaFoo = &MetaSetItem{Key: key, Value: []byte("new_bah_val"), Flags: MetaSetFlags{CompareCasTokenToUpdateValue: casToken, ClientFlagToken: &clientFlagToken, UpdateTTLToken: &newTTL}}
+	metaFoo = &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{CompareCasTokenToUpdateValue: casToken, ClientFlagToken: &clientFlagToken, UpdateTTLToken: &newTTL}}
 	response, err = c.MetaSet(metaFoo)
-	checkErr(err, "second meta set(%s): %v", key, err)
+	checkErr(err, "Same CAS token meta set(%s): %v", key, err)
+	it, err := c.Get(key)
+	if it.Flags != clientFlagToken {
+		t.Errorf("Same CAS token meta set(%s) expected client flag %d but got %d", key, clientFlagToken, it.Flags)
+	}
+	testMetaSetSavedValue(t, c, checkErr, key, value)
+
+	// set using a different cas token
+	value = []byte("byte_val_invalid")
+	var newCasToken uint64 = 123456789
+	metaFoo = &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{CompareCasTokenToUpdateValue: &newCasToken}}
+	_, err = c.MetaSet(metaFoo)
+	if err != ErrCASConflict {
+		t.Errorf("Differnet CAS token meta set(%s) expected an CAS conflict error but got %e", key, err)
+	}
 
 	// set with no reply semantics turned on
 	// note that the documentation says that this flag will always return an error (even if the command runs successfully)
-	metaFoo = &MetaSetItem{Key: key, Value: []byte("with_base64_key"), Flags: MetaSetFlags{UseNoReplySemanticsForResponse: true}}
+	value = []byte("with_base64_key")
+	metaFoo = &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{UseNoReplySemanticsForResponse: true}}
 	_, err = c.MetaSet(metaFoo)
+	// the error raised is an internal error, so we can't change for explicit type
 	if err == nil {
-		t.Errorf("third meta set(%s) expected an error to be returned but got none", key)
+		t.Errorf("no reply meta set(%s) expected an error to be returned but got none", key)
 	}
 
-	// set using the append mode
-	metaFoo = &MetaSetItem{Key: key, Value: []byte("append_value_to_existing"), Flags: MetaSetFlags{SetModeToken: Append}}
+	// set using the append mode with existing key
+	valueToAppend := []byte("append_value_to_existing")
+	value = append(value, valueToAppend...)
+	metaFoo = &MetaSetItem{Key: key, Value: valueToAppend, Flags: MetaSetFlags{SetModeToken: Append}}
 	_, err = c.MetaSet(metaFoo)
-	checkErr(err, "fourth meta set(%s): %v", key, err)
+	checkErr(err, "successful append meta set(%s): %v", key, err)
+	testMetaSetSavedValue(t, c, checkErr, key, value)
 
 	// set using the prepend mode
-	metaFoo = &MetaSetItem{Key: key, Value: []byte("prepend_value_to_existing"), Flags: MetaSetFlags{SetModeToken: Prepend}}
+	valueToPrepend := []byte("prepend_value_to_existing")
+	value = append(valueToPrepend, value...)
+	metaFoo = &MetaSetItem{Key: key, Value: valueToPrepend, Flags: MetaSetFlags{SetModeToken: Prepend}}
 	_, err = c.MetaSet(metaFoo)
-	checkErr(err, "fifth meta set(%s): %v", key, err)
+	checkErr(err, "successful prepend meta set(%s): %v", key, err)
+	testMetaSetSavedValue(t, c, checkErr, key, value)
 
 	// set using the add mode and existing key
 	// will fail to store and return ErrNotStored error because key is in use
 	metaFoo = &MetaSetItem{Key: key, Value: []byte("add_value_to_existing"), Flags: MetaSetFlags{SetModeToken: Add}}
 	_, err = c.MetaSet(metaFoo)
-	if err == nil {
-		t.Errorf("sixth meta set(%s) expected an error to be returned but got none", key)
+	if err != ErrNotStored {
+		t.Errorf("add mode with existing key meta set(%s) expected not stored error but got %e", key, err)
 	}
 
 	// set using the replace mode
-	metaFoo = &MetaSetItem{Key: key, Value: []byte("add_value_to_existing"), Flags: MetaSetFlags{SetModeToken: Replace}}
+	value = []byte("replacement_value")
+	metaFoo = &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{SetModeToken: Replace}}
 	_, err = c.MetaSet(metaFoo)
-	checkErr(err, "seventh meta set(%s): %v", key, err)
+	checkErr(err, "successful replace mode meta set(%s): %v", key, err)
+	testMetaSetSavedValue(t, c, checkErr, key, value)
 
 	// set using the add mode
-	// will fail to store and return ErrNotStored error because key is in use
-	metaFoo = &MetaSetItem{Key: "new_key", Value: []byte("add_value_to_existing"), Flags: MetaSetFlags{SetModeToken: Add}}
+	// will store because key is not in use
+	key = "new_key"
+	value = []byte("add_value_to_new_key")
+	metaFoo = &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{SetModeToken: Add}}
 	_, err = c.MetaSet(metaFoo)
-	checkErr(err, "eighth meta set(%s): %v", key, err)
+	checkErr(err, "add mode without existing key meta set(%s): %v", key, err)
+	testMetaSetSavedValue(t, c, checkErr, key, value)
 
-	// set using base64 encoded string (non-encoded is newBaseKey)
+	// set using base64 encoded string
 	key = "bmV3QmFzZUtleQ=="
-	metaFoo = &MetaSetItem{Key: key, Value: []byte("with_base64_key"), Flags: MetaSetFlags{IsKeyBase64: true}}
+	decodedKey := "newBaseKey"
+	value = []byte("with_base64_key")
+	metaFoo = &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{IsKeyBase64: true}}
 	_, err = c.MetaSet(metaFoo)
-	checkErr(err, "ninth meta set(%s): %v", key, err)
+	checkErr(err, "base64 encoded key meta set(%s): %v", key, err)
+	testMetaSetSavedValue(t, c, checkErr, decodedKey, value)
+
+	// set using the append mode with non-existent key
+	valueToAppend = []byte("new_append_value")
+	key = "non_existing_for_append"
+	metaFoo = &MetaSetItem{Key: key, Value: valueToAppend, Flags: MetaSetFlags{SetModeToken: Append}}
+	_, err = c.MetaSet(metaFoo)
+	if err != ErrNotStored {
+		t.Errorf("Append with non-existent key meta set(%s) expected a not stored error but got %e", key, err)
+	}
+
+	// set using the prepend mode with non-existent key
+	valueToPrepend = []byte("new_prepend_value")
+	key = "non_existing_for_prepend"
+	metaFoo = &MetaSetItem{Key: key, Value: valueToPrepend, Flags: MetaSetFlags{SetModeToken: Prepend}}
+	_, err = c.MetaSet(metaFoo)
+	if err != ErrNotStored {
+		t.Errorf("Prepend with non-existent key meta set(%s) expected a not stored error but got %e", key, err)
+	}
+
+	// set using the replace mode with non-existent key
+	value = []byte("new_replace_value")
+	key = "non_existing_for_replace"
+	metaFoo = &MetaSetItem{Key: key, Value: value, Flags: MetaSetFlags{SetModeToken: Replace}}
+	_, err = c.MetaSet(metaFoo)
+	if err != ErrNotStored {
+		t.Errorf("Replace with non-existent key meta set(%s) expected a not stored error but got %e", key, err)
+	}
+}
+
+func testMetaSetSavedValue(t *testing.T, c *Client, checkErr func(err error, format string, args ...interface{}), key string, value []byte) {
+	it, err := c.Get(key)
+	checkErr(err, "get(%s): %v", key, err)
+	if it.Key != key {
+		t.Errorf("get(%s) Key = %q, want %s", key, it.Key, key)
+	}
+	if bytes.Compare(it.Value, value) != 0 {
+		t.Errorf("get(%s) Value = %q, want %q", key, string(it.Value), string(value))
+	}
 }
 
 func stringSlicesEqual(a, b []byte) bool {


### PR DESCRIPTION
### Problem
- The current go library for memcached has no interface for the meta commands that memcached supports. These commands provide a lot more flexibility when working with them as you can use in-line flags to perform work that would typically require several commands to do.

### What this PR covers
- This covers an initial implementation of the meta set command implementation for the library only for flags which do not provide a return value- such flags will receive support in a later PR.